### PR TITLE
ENH: Bump hackathon capsule version to v2 release

### DIFF
--- a/HCK02_2023_Allen_Institute_Hybrid/Tutorials/AboutTheAINDLightsheetChallengeDataset.md
+++ b/HCK02_2023_Allen_Institute_Hybrid/Tutorials/AboutTheAINDLightsheetChallengeDataset.md
@@ -31,7 +31,7 @@ Duration: 0.5 hours.
 <!-- Describe here how the tutorial will be taught, e.g. slides, Jupyter
 notebooks, and provide links to any materials. -->
 
-- [Reference registration pipeline Code Ocean Capsule](https://codeocean.allenneuraldynamics.org/capsule/5051231/tree/v1)
+- [Reference registration pipeline Code Ocean Capsule](https://codeocean.allenneuraldynamics.org/capsule/5051231/tree/v2)
 - [Reference registration pipeline GitHub Repository](https://github.com/AllenNeuralDynamics/get-your-brain-together-23)
 - [AWS Open Data Allen Institute for Neural Dynamics - Mouse Neuroanatomy and Physiology Data](https://aws.amazon.com/marketplace/pp/prodview-wrdmo2cy2pnze?sr=0-1&ref_=beagle&applicationId=AWSMPContessa)
 


### PR DESCRIPTION
v2 release includes documentation fixes and a new notebook demo for applying transform results to SmartSPIM point set annotation data.